### PR TITLE
check the result of ERC20 transfer and transferFrom calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,10 @@ requirements-dev.txt: pyproject.toml
 	$(VENV)/bin/pip-compile -o requirements-dev.txt --extra dev pyproject.toml
 
 unit-tests: ${VENV}
-	${VENV}/bin/pytest tests/unit --durations=0 -n auto
+	${VENV}/bin/pytest tests/unit --durations=20 -n auto
 
 integration-tests: ${VENV}
-	${VENV}/bin/pytest -n auto tests/integration -m "not profile" --durations=0
+	${VENV}/bin/pytest -n auto tests/integration -m "not profile" --durations=20
 
 fuzz-tests:
 	${VENV}/bin/pytest tests/fuzz --durations=0 -n auto

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -145,7 +145,7 @@ def start_rental(renter: address, expiration: uint256) -> Rental:
         IDelegationRegistry(self.delegation_registry_addr).setHotWallet(renter, expiration, False)
 
     # transfer rental amount from renter to this contract
-    IERC20(self.payment_token_addr).transferFrom(renter, self, rental_amount)
+    assert IERC20(self.payment_token_addr).transferFrom(renter, self, rental_amount), "transferFrom failed"
 
     return self.active_rental
 
@@ -183,7 +183,7 @@ def close_rental(sender: address) -> (Rental, uint256):
     IDelegationRegistry(self.delegation_registry_addr).setHotWallet(empty(address), 0, False)
 
     # transfer unused payment to renter
-    IERC20(self.payment_token_addr).transfer(rental.renter, payback_amount)
+    assert IERC20(self.payment_token_addr).transfer(rental.renter, payback_amount), "transfer failed"
 
     return rental, pro_rata_rental_amount
 
@@ -204,7 +204,7 @@ def claim(sender: address) -> uint256:
     self.unclaimed_rewards = 0
 
     # transfer reward to nft owner
-    IERC20(self.payment_token_addr).transfer(self.active_rental.owner, rewards_to_claim)
+    assert IERC20(self.payment_token_addr).transfer(self.active_rental.owner, rewards_to_claim), "transfer failed"
 
     return rewards_to_claim
 
@@ -235,7 +235,7 @@ def withdraw(sender: address) -> uint256:
 
     # transfer unclaimed rewards to owner
     if rewards_to_claim > 0:
-        IERC20(self.payment_token_addr).transfer(owner, rewards_to_claim)
+        assert IERC20(self.payment_token_addr).transfer(owner, rewards_to_claim), "transfer failed"
 
     return rewards_to_claim
 


### PR DESCRIPTION
## Purpose of this PR 🎯

<!-- Check at least one of the following options with an "x". -->
-   [ ] Feature;
-   [x] Bugfix;
-   [ ] Patch;
-   [ ] Tests;
-   [ ] Refactoring;
-   [ ] Build or CI/CD;
-   [ ] Documentation;
-   [ ] Code Styling;
-   [ ] Other. Please describe:

## Changes 📝
Fixes audit `M01. Unchecked Return Value/ Violation of Best Practices` 
```
The functions do not use the SafeERC20 library for checking result of ERC20 token transfers. Tokens may not follow the ERC20 standard and return false in case of transfer failure or not returning any value at all.
```
Calls to `IERC20.transfer` and `IERC20.transferFrom` now check the return value and revert if is `False`.
This accounts for ERC20 implementations that fail by reverting or by returning `False`. The failure mode for non-standard ERC20 implementations (no return value) is to revert, meaning those are not supported by the protocol.


<!-- Describe the changes introduced by this PR. -->
<!-- If applicable add screenshots or videos that illustrate any new or updated UIs. -->
